### PR TITLE
Add common shell characters to lua capture regex

### DIFF
--- a/luar.kak
+++ b/luar.kak
@@ -12,8 +12,8 @@ provide-module luar %#
     require-module kak
     require-module lua
 
-    add-highlighter shared/kakrc/lua1 region -recurse '\{' '(^|\h)\K%?lua([\s{}\w%/$-|'"])* %\{' '\}' ref lua
-    add-highlighter shared/kakrc/lua2 region -recurse '\(' '(^|\h)\K%?lua([\s{}\w%/$-|'"])* %\(' '\)' ref lua
-    add-highlighter shared/kakrc/lua3 region -recurse '\[' '(^|\h)\K%?lua([\s{}\w%/$-|'"])* %\[' '\]' ref lua
-    add-highlighter shared/kakrc/lua4 region -recurse '<' '(^|\h)\K%?lua([\s{}\w%/$-|'"])* %<' '>' ref lua
+    add-highlighter shared/kakrc/lua1 region -recurse '\{' '(^|\h)\K%?lua([\s{}\w%/$-|''"])* %\{' '\}' ref lua
+    add-highlighter shared/kakrc/lua2 region -recurse '\(' '(^|\h)\K%?lua([\s{}\w%/$-|''"])* %\(' '\)' ref lua
+    add-highlighter shared/kakrc/lua3 region -recurse '\[' '(^|\h)\K%?lua([\s{}\w%/$-|''"])* %\[' '\]' ref lua
+    add-highlighter shared/kakrc/lua4 region -recurse '<' '(^|\h)\K%?lua([\s{}\w%/$-|''"])* %<' '>' ref lua
 #

--- a/luar.kak
+++ b/luar.kak
@@ -12,8 +12,8 @@ provide-module luar %#
     require-module kak
     require-module lua
 
-    add-highlighter shared/kakrc/lua1 region -recurse '\{' '(^|\h)\K%?lua([\s{}\w%/"])* %\{' '\}' ref lua
-    add-highlighter shared/kakrc/lua2 region -recurse '\(' '(^|\h)\K%?lua([\s{}\w%/"])* %\(' '\)' ref lua
-    add-highlighter shared/kakrc/lua3 region -recurse '\[' '(^|\h)\K%?lua([\s{}\w%/"])* %\[' '\]' ref lua
-    add-highlighter shared/kakrc/lua4 region -recurse '<' '(^|\h)\K%?lua([\s{}\w%/"])* %<' '>' ref lua
+    add-highlighter shared/kakrc/lua1 region -recurse '\{' '(^|\h)\K%?lua([\s{}\w%/$-|'"])* %\{' '\}' ref lua
+    add-highlighter shared/kakrc/lua2 region -recurse '\(' '(^|\h)\K%?lua([\s{}\w%/$-|'"])* %\(' '\)' ref lua
+    add-highlighter shared/kakrc/lua3 region -recurse '\[' '(^|\h)\K%?lua([\s{}\w%/$-|'"])* %\[' '\]' ref lua
+    add-highlighter shared/kakrc/lua4 region -recurse '<' '(^|\h)\K%?lua([\s{}\w%/$-|'"])* %<' '>' ref lua
 #


### PR DESCRIPTION
The current highlighter for lua regions breaks on something like this
```
  lua %val{bufname} %sh{ echo "$kak_quoted_buflist" | xargs -n1 printf '%s\n' } %{ ... }
```
because the characters `$|-'` aren't in the region capture regex. I've also added the characters `-|'`, since they are common for shell operations (`-args`, pipes, and single-quotes).