### PR TITLE
Allow specifying a Lua interpreter to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ Since Lua modules are just plain tables and `require` is just a simple function,
 ```lua
 lua %val{buffile} %{
     local lpeg = require "lpeg"
-    
+
     local function parse(file)
         -- do the lpeg's magic here
     end
-    
+
     local tree = parse(arg[1])
     -- ...
 }
@@ -150,4 +150,13 @@ You must have a `lua` interpreter installed on your system. Then you can add the
 plug "gustavo-hms/luar" %{
     require-module luar
 }
+```
+
+## Configuration
+
+You can also change the Lua interpreter used by this plugin by changing the `luar_interpreter` option, e.g.:
+
+```kak
+# use luajit to run all Lua snippets
+set-option global luar_interpreter luajit
 ```

--- a/luar.asciidoc
+++ b/luar.asciidoc
@@ -122,11 +122,11 @@ contents of a file, you can use the elegant LPeg library:
 ----
 lua %val{buffile} %{
     local lpeg = require "lpeg"
-    
+
     local function parse(file)
         -- do the lpeg's magic here
     end
-    
+
     local tree = parse(arg[1])
     -- ...
 }
@@ -134,6 +134,17 @@ lua %val{buffile} %{
 
 You can also use this functionality to split your plugin into separate
 modules and use `:lua` to glue them together.
+
+== Configuration
+
+You can also change the Lua interpreter used by this plugin by changing the
+`luar_interpreter` option, e.g.:
+
+[source,kak]
+----
+# use luajit to run all Lua snippets
+set-option global luar_interpreter luajit
+----
 
 == Some examples
 
@@ -162,13 +173,13 @@ declare-option -hidden bool highlight_search_on false
 define-command highlight-search-toggle %{
     lua %opt{highlight_search_on} %{
         local is_on = args()
-    
+
         if is_on then
             kak.remove_highlighter("window/highlight-search")
         else
             kak.add_highlighter("window/highlight-search", "dynregex", "%reg{/}", "0:default,+ub")
         end
-    
+
         kak.set_option("window", "highlight_search_on", not is_on)
     }
 }

--- a/luar.kak
+++ b/luar.kak
@@ -1,6 +1,6 @@
 declare-option -hidden str luar_path %sh{ dirname $kak_source }
 
-declare-option str luar_interpreter lua
+declare-option -docstring "The executable used to run any provided Lua code" str luar_interpreter lua
 
 provide-module luar %#
     define-command lua -params 1.. -docstring %{

--- a/luar.kak
+++ b/luar.kak
@@ -1,12 +1,14 @@
 declare-option -hidden str luar_path %sh{ dirname $kak_source }
 
+declare-option str luar_interpreter lua
+
 provide-module luar %#
     define-command lua -params 1.. -docstring %{
         lua [<switches>] [args...] code: Execute provided Lua code as an anonymous function whose arguments are the args list.
         Switches:
             -debug Print Kakoune commands to *debug* buffer instead of executing them.
     } %{ eval %sh{
-        lua "$kak_opt_luar_path/luar.lua" "$@"
+        $kak_opt_luar_interpreter "$kak_opt_luar_path/luar.lua" "$@"
     }}
 
     require-module kak

--- a/luar.kak
+++ b/luar.kak
@@ -1,6 +1,6 @@
 declare-option -hidden str luar_path %sh{ dirname $kak_source }
 
-declare-option -docstring "The executable used to run any provided Lua code" str luar_interpreter lua
+declare-option -docstring "The Lua interpreter used to execute Lua code" str luar_interpreter lua
 
 provide-module luar %#
     define-command lua -params 1.. -docstring %{


### PR DESCRIPTION
This allows people to use `luajit` and any other custom interpreters by setting a new `luar_interpreter` option while still using the `lua` executable by default.

Thought on this?